### PR TITLE
issue74: fix off by one error

### DIFF
--- a/PUBLISHING.rst
+++ b/PUBLISHING.rst
@@ -49,6 +49,7 @@ After merging a pull request on Github:
 
 #. Build a distributable package with the ``setup.py`` script::
 
+     > rm -rf dist/*
      > python setup.py sdist bdist_wheel
      > ls -1 dist/
      orgcrawler-1.0.0a5-py3-none-any.whl

--- a/orgcrawler/crawlers.py
+++ b/orgcrawler/crawlers.py
@@ -3,7 +3,7 @@ import time
 
 from botocore.exceptions import ClientError
 
-from orgcrawler import utils, logger
+from orgcrawler import utils
 
 
 DEFAULT_REGION = 'us-east-1'
@@ -172,7 +172,6 @@ class CrawlerExecution(object):
     def __init__(self, payload):
         self.payload = payload
         self.name = payload.__name__
-        self.logger = logger.Logger()
         self.responses = []
         self.errors = 0
         self.errmsg = None
@@ -191,13 +190,13 @@ class CrawlerExecution(object):
             (response for response in self.responses if response.exc_info)
         ).exc_info
         self.errmsg = (
-            'OrgCrawler.execute encountered {} errors while running "{}". '
-            'Example:\n'.format(
+            'OrgCrawler.execute encountered {} exceptions while running payload function "{}". '
+            '\n\nExample traceback:'.format(
                 self.errors,
                 self.name,
             )
         )
-        self.logger.error(self.errmsg)
+        print(self.errmsg, file=sys.stderr)
         sys.excepthook(*exc_info)
         sys.exit()
 

--- a/test/README.rst
+++ b/test/README.rst
@@ -13,3 +13,7 @@ Testing org setup for TooManyRequestsException errors:
   done
 
 
+Test individual module::
+
+  pytest --disable-warnings --no-cov --verbose test_blee.py
+

--- a/test/test_crawlers.py
+++ b/test/test_crawlers.py
@@ -9,7 +9,7 @@ from moto import (
     mock_s3,
 )
 
-from orgcrawler import crawlers, orgs, utils, logger
+from orgcrawler import crawlers, orgs, utils
 from orgcrawler.mock.org import (
     MockOrganization,
     ORG_ACCESS_ROLE,
@@ -58,7 +58,6 @@ def test_crawler_execution_init():
     assert execution.name == 'get_mock_account_alias'
     assert execution.responses == []
     assert isinstance(execution.timer, crawlers.CrawlerTimer)
-    assert isinstance(execution.logger, logger.Logger)
     assert isinstance(execution.dump(), dict)
 
 

--- a/test/test_crawlers.py
+++ b/test/test_crawlers.py
@@ -9,7 +9,7 @@ from moto import (
     mock_s3,
 )
 
-from orgcrawler import crawlers, orgs, utils
+from orgcrawler import crawlers, orgs, utils, logger
 from orgcrawler.mock.org import (
     MockOrganization,
     ORG_ACCESS_ROLE,
@@ -58,6 +58,7 @@ def test_crawler_execution_init():
     assert execution.name == 'get_mock_account_alias'
     assert execution.responses == []
     assert isinstance(execution.timer, crawlers.CrawlerTimer)
+    assert isinstance(execution.logger, logger.Logger)
     assert isinstance(execution.dump(), dict)
 
 
@@ -236,8 +237,12 @@ def test_execute():
     assert crawler.get_execution('get_mock_account_alias') == crawler.executions[1]
     assert crawler.get_execution('create_mock_bucket') == crawler.executions[2]
 
+    # test error handling
     with pytest.raises(SystemExit):
-        bad_execution = crawler.execute(bad_payload_func)
+        crawler.execute(bad_payload_func)
+    bad_execution = crawler.get_execution('bad_payload_func')
+    assert isinstance(bad_execution.errmsg, str) 
+    assert bad_execution.errmsg.split()[2] == str(len(bad_execution.responses))
 
 
 args = ('cat', 'dog', 'rat')


### PR DESCRIPTION
add logger to OrgcrawlerExecution object
OrgcrawlerExecution.errors is no and int, no longer a bool

tests passing
need to see how errors look in the wild before merging